### PR TITLE
Fix current hadolint and container-scan CI problems

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,5 +1,5 @@
-general:
-  vulnerabilities:
-    - CVE-2020-12351
-    - CVE-2020-16119
-    - CVE-2020-1971
+# general:
+#   vulnerabilities:
+#     - CVE-2020-12351
+#     - CVE-2020-16119
+#     - CVE-2020-1971

--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,5 +1,0 @@
-# general:
-#   vulnerabilities:
-#     - CVE-2020-12351
-#     - CVE-2020-16119
-#     - CVE-2020-1971

--- a/.github/linters/.hadolint.yml
+++ b/.github/linters/.hadolint.yml
@@ -1,2 +1,4 @@
 ignored:
-  - DL3008
+  # it's good to be in sync with the latest versions of the tools and only pin versions in specific cases
+  - DL3008 # warning: Pin versions in apt get install.
+  - DL3013 # warning: Pin versions in pip.

--- a/.github/workflows/action-image-scan-integration.yaml
+++ b/.github/workflows/action-image-scan-integration.yaml
@@ -15,12 +15,13 @@ jobs:
         ros-distro: [foxy, dashing]
     env:
       ROS_DISTRO: ${{ matrix.ros-distro }}
+      TRIVY_IGNORE_UNFIXED: 1
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 
     - run: docker build --build-arg ROS_DISTRO=$ROS_DISTRO -t oriserobotics/ros-$ROS_DISTRO:devel .
-      
+
     - uses: Azure/container-scan@v0
       with:
         image-name: oriserobotics/ros-${{ env.ROS_DISTRO }}:devel

--- a/.github/workflows/action-image-scan-integration.yaml
+++ b/.github/workflows/action-image-scan-integration.yaml
@@ -7,7 +7,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   docker-best-practices:
     strategy:

--- a/.github/workflows/action-image-scan-integration.yaml
+++ b/.github/workflows/action-image-scan-integration.yaml
@@ -16,7 +16,7 @@ jobs:
         ros-distro: [foxy, dashing]
     env:
       ROS_DISTRO: ${{ matrix.ros-distro }}
-      TRIVY_IGNORE_UNFIXED: 1
+      # TRIVY_IGNORE_UNFIXED: 1
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/super_lint.yaml
+++ b/.github/workflows/super_lint.yaml
@@ -9,7 +9,6 @@ jobs:
     - name: super lint
       uses: github/super-linter@v3
       env:
-        # VALIDATE_ALL_CODEBASE: false # TOOD: uncomment on next PR
         DEFAULT_BRANCH: main
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FILTER_REGEX_EXCLUDE: \.github\/pull_request_template.md

--- a/.github/workflows/super_lint.yaml
+++ b/.github/workflows/super_lint.yaml
@@ -1,5 +1,9 @@
 name: Super Lint
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   super-lint:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
     && rm -rf /var/lib/apt/lists/*
 
 # install ament_flake8 non-declared pip deps
-RUN pip3 install \
+RUN pip3 install --no-cache-dir \
     flake8-blind-except \
     flake8-builtins \
     flake8-class-newline \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN set -eux; \
 
 # install common dev tools
 RUN export DEBIAN_FRONTEND=noninteractive; \
-    apt-get update && apt-get upgrade -y --no-install-recommends && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     bash-completion \
     pkg-config \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN set -eux; \
 
 # install common dev tools
 RUN export DEBIAN_FRONTEND=noninteractive; \
-    apt-get update && \
+    apt-get update && apt-get upgrade -y --no-install-recommends && \
     apt-get install -y --no-install-recommends \
     bash-completion \
     pkg-config \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*; \
     gosu nobody true
 
+# make security updates
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends unattended-upgrades && unattended-upgrade && \
+    rm -rf /var/lib/apt/lists/*
+
 # install common dev tools
 RUN export DEBIAN_FRONTEND=noninteractive; \
     apt-get update && \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     && rm -rf /var/lib/apt/lists/*
 
 # install ament_flake8 non-declared pip deps
-RUN pip3 install \
+RUN pip3 install --no-cache-dir \
     flake8-blind-except \
     flake8-builtins \
     flake8-class-newline \


### PR DESCRIPTION
### Description
- Fix hadolint problem by ignoring version-pinning checks. I prefer to put effort into adapting to the latest versions of the dependencies and only pin versions when necessary and by demand
- Fix vulnerability problems by ~~upgrading all packages~~ installing security updates with `unattended-upgrades`. One downside of this step is that it takes a bit longer to build the image, ~~especially considering it also update ROS packages from the `ros-$distro-base` base image~~. However, it seems to solve most of the problems
- ~~Try to set ignore-unfixed flag used in container-scan check through [trivy](https://github.com/aquasecurity/trivy)~~ (the result was the same, so I'll keep without it)
- Setup periodic tests to avoid more surprises in the future

### Related Issues:
- closes #34
