### PR TITLE
Share gnupg folder and set GPG_TTY variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,8 @@ RUN mkdir -p /home/${DOCKER_USER}/devel_ws && chown ${DOCKER_USER}:${DOCKER_USER
 RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> /etc/bash.bashrc
 RUN echo "PS1='\[\033[01;35m\]ros-$ROS_DISTRO@devel\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '" >> /etc/skel/.bashrc
 
+ENV GPG_TTY=$(tty)
+
 WORKDIR /home/${DOCKER_USER}/devel_ws
 
 COPY docker-entrypoint.sh /usr/bin/docker-entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - ~/.ssh/known_hosts:/home/orise/.ssh/known_hosts:rw
       - ~/.ssh/id_rsa:/home/orise/.ssh/id_rsa:ro
       - ~/.ssh/id_rsa.pub:/home/orise/.ssh/id_rsa.pub:ro
+      - ~/.gnupg:/home/orise/.gnupg:rw
       - ~/.gitconfig:/etc/gitconfig:ro
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - $VOLUMES_FOLDER/$CONTAINER_NAME:/home/orise:rw


### PR DESCRIPTION
### Description
1. Share .gnupg folder and set GPG_TTY variable to allow commit sign-off with GPG keys

### Related Issues:
- fix #37 
