### PR TITLE
Feature/ssh agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
     pkg-config \
     git \
     python3-pip \
+    ssh \
     vim \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ will attach to the container `ros-melodic-devel`.
 
 We recommend you to try [vscode_ros2_ws](https://github.com/orise-robotics/vscode_ros2_ws), a vscode workspace with all the tools needed to develop ROS2 packages in ORise's development containers with ease.
 
+To be able to pull/push private repositories with SSH keys available in the host environment, the user needs to add the private key to ssh-agent by running `ssh-add PRIVATE_KEY_PATH`.
+
 ## Test in a Container
 
 The script `run_test.sh` starts a test container given the target ROS distro, then test the target package selected from the provided source list ([vcstools](https://github.com/dirk-thomas/vcstool) format). For example:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ will attach to the container `ros-melodic-devel`.
 
 We recommend you to try [vscode_ros2_ws](https://github.com/orise-robotics/vscode_ros2_ws), a vscode workspace with all the tools needed to develop ROS2 packages in ORise's development containers with ease.
 
-To be able to pull/push private repositories with SSH keys available in the host environment, the user needs to add the private key to ssh-agent by running `ssh-add PRIVATE_KEY_PATH`.
+To be able to pull/push private repositories with SSH keys available in the host environment, the user just need to add a private key to `ssh-agent` ([Tutorial on Generating a new SSH key and adding it to the ssh-agent](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)).
 
 ## Test in a Container
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,10 @@ services:
       - DISPLAY
       - COLCON_WORKSPACE_FOLDER=$COLCON_WORKSPACE_FOLDER
       - USER=orise
+      - SSH_AUTH_SOCK=$SSH_AUTH_SOCK_CONTAINER_PATH
     network_mode: host
     volumes:
-      - ~/.ssh/known_hosts:/home/orise/.ssh/known_hosts:rw
-      - ~/.ssh/id_rsa:/home/orise/.ssh/id_rsa:ro
-      - ~/.ssh/id_rsa.pub:/home/orise/.ssh/id_rsa.pub:ro
+      - $SSH_AUTH_SOCK_HOST_PATH:$SSH_AUTH_SOCK_CONTAINER_PATH
       - ~/.gnupg:/home/orise/.gnupg:rw
       - ~/.gitconfig:/etc/gitconfig:ro
       - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/run-devel.sh
+++ b/run-devel.sh
@@ -50,6 +50,8 @@ fi
 ROS_DISTRO=$ROS_DISTRO \
   VOLUMES_FOLDER=$VOLUMES_FOLDER \
   CONTAINER_NAME=$CONTAINER_NAME \
+  SSH_AUTH_SOCK_HOST_PATH="$SSH_AUTH_SOCK" \
+  SSH_AUTH_SOCK_CONTAINER_PATH="/home/orise/.ssh-agent/ssh-agent.sock" \
   docker-compose -p "$ROS_DISTRO" --env-file .env up $BUILD_IMAGE_OPT -d devel
 
 docker exec -ti --user orise "$CONTAINER_NAME" /bin/bash


### PR DESCRIPTION
### Description

Share ssh keys with ssh-agent forwarding rather than sharing the ssh key files directly. It is accomplished by sharing the ssh-agent socket. The user just needs to add the private key with `ssh-add YOUR_PRIVATE_KEY_PATH`.

### Related Issues:
- #38 